### PR TITLE
Fix readme and improve warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@ A bruteforcer that looks for combinations of platform angle, Mario's speed, and 
 
 # Building
 
-**Linux**
-```bash
-make
-```
+Here are the dependencies, and how to install them.
 
-**Windows**
-You'll need to install Ninja if you haven't already.
-```bash
-ninja
-```
+Dependency | Windows | Linux (APT) |
+:---------|:-------|:-----------|
+Clang | Download from [here](https://github.com/llvm/llvm-project/releases/latest) | `sudo apt-get install clang`
+Ninja | `pip install ninja` | `sudo apt-get install ninja-build`
+
+
+Simply run `build.py` in some relatively recent version of Python 3.
+If you want to change the flags, they are all available in `configure.py`
+
+# Notes for contributors
+
+If you want to change the build flags, do so in both `build/Makefile` and `configure.py`.

--- a/build.py
+++ b/build.py
@@ -1,12 +1,93 @@
+#!/usr/bin/env python3
 from pathlib import Path
 import subprocess
+import sys
+import platform
 import os
+from textwrap import dedent
 
 proj_dir = Path(__file__).parent
 
 os.chdir(proj_dir)
 
+# https://stackoverflow.com/questions/377017/test-if-executable-exists-in-python/377028#377028
+# This is necessary.
+
+
 if not proj_dir.joinpath("build.ninja").exists():
     subprocess.run(["python3", "configure.py"])
+    
+try:
+    subprocess.run("clang++", stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+except FileNotFoundError:
+    print("You need to install clang.")
+    print("To install clang:")
+    if platform.system() == "Linux":
+        # check the system's package manager
+        proc = subprocess.run(
+            ["lsb_release", "-d"], 
+            encoding="utf-8",
+            capture_output=True
+        )
+        desc = proc.stdout;
+        desc = desc[desc.find(":") + 1:].strip()
+        print(desc)
+        # Taken from https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages
+        if "Ubuntu" in desc or "Debian" in desc:
+            print("Run \"sudo apt-get install clang\"")
+        elif "Fedora" in desc.lower():
+            print("Run \"sudo dnf install clang\"")
+        elif "Arch" in desc:
+            print("Run \"pacman -S clang\"")
+        else:
+            print(dedent("""\
+            1. Search for \"clang\" or \"llvm\" on your system's package manager.
+            2. Install it.
+            """))
+    else:
+        print("""\
+        Go to this link -> https://github.com/llvm/llvm-project/releases/latest
+        And find the version of Clang for your system.
+        """)
+    sys.exit(12)
+        
 
-subprocess.run(["ninja"])
+try:
+    subprocess.run(["ninja"])
+except FileNotFoundError:
+    print("You need to install Ninja.")
+    print("To install Ninja:")
+    if platform.system() == "Windows":
+        print(dedent("""
+        1. Make sure you have access to pip.
+        2. Run "pip install ninja", without the quotes.
+        """))
+    if platform.system() == "Linux":
+        # check the system's package manager
+        proc = subprocess.run(
+            ["lsb_release", "-d"], 
+            encoding="utf-8",
+            capture_output=True
+        )
+        desc = proc.stdout;
+        desc = desc[desc.find(":") + 1:].strip()
+        # Taken from https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages
+        if "Ubuntu" in desc or "Debian" in desc:
+            print("Run \"sudo apt-get install ninja-build\" (without the quotes)")
+        elif "Fedora" in desc:
+            print("Run \"sudo dnf install ninja-build\" (without the quotes)")
+        elif "Arch" in desc:
+            print("Run \"pacman -S ninja\" (without the quotes)")
+        else:
+            print(
+                "Go to https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages and " +
+                "see how you're supposed to install Ninja on your Linux distro. \n" +
+                "I was too lazy to put them all in."
+            )
+    else:
+        print(
+            "Go to https://github.com/ninja-build/ninja and " +
+            "figure out how you can install Ninja. \n" +
+            "Note that building outside of Windows and Linux is untested."
+        )
+    sys.exit(12)

--- a/build.py
+++ b/build.py
@@ -18,7 +18,7 @@ if not proj_dir.joinpath("build.ninja").exists():
     subprocess.run(["python3", "configure.py"])
     
 try:
-    subprocess.run("clang++", stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+    subprocess.run(["clang++", "-v"], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 except FileNotFoundError:
     print("You need to install clang.")
     print("To install clang:")

--- a/configure.py
+++ b/configure.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3 
 import sys
 from pathlib import Path
 
@@ -60,7 +61,7 @@ with open("build.ninja", "w") as f:
         description="Regenerating build script..."
     )
     
-    file.rule("compile", "$cxx $cxx_flags -MD -MF $out.d -c $in -o $out", 
+    file.rule("compile", "$cxx $cxx_flags -MMD -MF $out.d -c $in -o $out", 
         depfile="$out.d",
         description="Compiling $out"
     )


### PR DESCRIPTION
The original `build.py` didn't give you a particularly clear error message when failing to run Ninja or Clang. This commit adds the following:

- Runs `clang++ -v` to check for clang's presence.
- If either the clang version check or the ninja check fails, you'll get an error message telling you how to install either package

In addition, the readme now tells you how to get the dependencies.